### PR TITLE
Concurrent dictionary usage

### DIFF
--- a/src/LogoFX.Client.Mvvm.ViewModel.Contracts/IEditableViewModel.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel.Contracts/IEditableViewModel.cs
@@ -2,13 +2,33 @@
 
 namespace LogoFX.Client.Mvvm.ViewModel.Interfaces
 {
+    /// <summary>
+    /// Represents an editable view model
+    /// </summary>
     public interface IEditableViewModel
     {
+        /// <summary>
+        /// Returns <see cref="true"/> if the view model has changes, <see cref="false"/> otherwise. />
+        /// </summary>
         bool IsDirty { get; }
+        /// <summary>
+        /// Returns <see cref="true"/> if the view model has errors, <see cref="false"/> otherwise. />
+        /// </summary>
         bool HasErrors { get; }
+        /// <summary>
+        /// Gets or sets the value which enables/disables undo operations.
+        /// </summary>
         bool CanUndo { get; set; }
         
+        /// <summary>
+        /// Reverts the last operation.
+        /// </summary>
         void Undo();
+
+        /// <summary>
+        /// Saves the state asynchronously
+        /// </summary>
+        /// <returns></returns>
         Task<bool> SaveAsync();        
     }
 }

--- a/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/BulkTests.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/BulkTests.cs
@@ -18,7 +18,7 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
             var modelTwo = new TestModel(5);            
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(SelectionMode.ZeroOrOne, isBulk: true, isConcurrent)
+                new WrappingCollection.WithSelection(SelectionMode.ZeroOrOne, isBulk: true, isConcurrent: isConcurrent)
                 {
                     FactoryMethod = o => o
                 }.WithSource(((IReadModelsCollection<TestModel>) source).Items);
@@ -39,7 +39,7 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
             var modelTwo = new TestModel(5);            
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(SelectionMode.ZeroOrOne, isBulk: true, isConcurrent)
+                new WrappingCollection.WithSelection(SelectionMode.ZeroOrOne, isBulk: true, isConcurrent: isConcurrent)
                 {
                     FactoryMethod = o => o
                 }.WithSource(((IReadModelsCollection<TestModel>) source).Items);

--- a/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/BulkTests.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/BulkTests.cs
@@ -8,15 +8,17 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
 {    
     public class BulkTests : WrappingCollectionTestsBase
     {
-        [Fact]
-        public void GivenCollectionIsBulkAndSourceWithTwoItemsIsAdded_WhenSecondItemIsRemoved_ThenCollectionContainsOneItem()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GivenCollectionIsBulkAndSourceWithTwoItemsIsAdded_WhenSecondItemIsRemoved_ThenCollectionContainsOneItem(bool isConcurrent)
         {
             var source = new RangeModelsCollection<TestModel>();
             var modelOne = new TestModel(4);
             var modelTwo = new TestModel(5);            
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(SelectionMode.ZeroOrOne, isBulk: true)
+                new WrappingCollection.WithSelection(SelectionMode.ZeroOrOne, isBulk: true, isConcurrent)
                 {
                     FactoryMethod = o => o
                 }.WithSource(((IReadModelsCollection<TestModel>) source).Items);
@@ -27,15 +29,17 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
             wrappingCollection.OfType<TestModel>().ToArray().Should().BeEquivalentTo(expectedModels);            
         }
 
-        [Fact]
-        public void GivenCollectionIsBulkAndSourceWithTwoItemsIsAdded_WhenAllItemsAreRemoved_ThenCollectionContainsNoItem()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void GivenCollectionIsBulkAndSourceWithTwoItemsIsAdded_WhenAllItemsAreRemoved_ThenCollectionContainsNoItem(bool isConcurrent)
         {
             var source = new RangeModelsCollection<TestModel>();
             var modelOne = new TestModel(4);
             var modelTwo = new TestModel(5);            
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(SelectionMode.ZeroOrOne, isBulk: true)
+                new WrappingCollection.WithSelection(SelectionMode.ZeroOrOne, isBulk: true, isConcurrent)
                 {
                     FactoryMethod = o => o
                 }.WithSource(((IReadModelsCollection<TestModel>) source).Items);

--- a/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/ConcurrencyTests.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/ConcurrencyTests.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.ObjectModel;
+using System.Threading;
+using FluentAssertions;
+using Xunit;
+
+namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
+{
+    public class ConcurrencyTests
+    {
+        static ConcurrencyTests()
+        {
+            Dispatch.Current = new DefaultDispatch();
+        }
+
+        [Fact]
+        public void Add_ModelIsAddedAndThenRemovedAndThenReAdded_ExceptionIsNotThrown()
+        {
+            var lastModel = new TestModel(3);
+            var dataSource =
+                new ObservableCollection<TestModel>(new[] {new TestModel(1), new TestModel(2)});
+
+            var wc = new WrappingCollection(r => r.UseConcurrent()).WithSource(dataSource);
+            dataSource.Add(lastModel);
+            dataSource.Remove(lastModel);
+            var exception = Record.Exception(() => dataSource.Add(lastModel));
+
+            exception.Should().BeNull();
+        }
+    }
+}

--- a/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/DataSourceCollectionChangedTests.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/DataSourceCollectionChangedTests.cs
@@ -8,14 +8,16 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
     public class DataSourceCollectionChangedTests : WrappingCollectionTestsBase
     {
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void DataSourceCollectionChanged_ModelIsAdded_ViewModelIsAdded(bool isConcurrent)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void DataSourceCollectionChanged_ModelIsAdded_ViewModelIsAdded(bool isBulk, bool isConcurrent)
         {
             var dataSource =
                 new ObservableCollection<TestModel>(new[] {new TestModel(1), new TestModel(2), new TestModel(3)});
 
-            var wrappingCollection = new WrappingCollection(false, isConcurrent) {FactoryMethod = o => new TestViewModel((TestModel)o)};
+            var wrappingCollection = new WrappingCollection(isBulk, isConcurrent) {FactoryMethod = o => new TestViewModel((TestModel)o)};
             wrappingCollection.AddSource(dataSource);
             dataSource.Add(new TestModel(4));
 
@@ -25,14 +27,16 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void DataSourceCollectionChanged_ModelIsRemoved_ViewModelIsRemoved(bool isConcurrent)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void DataSourceCollectionChanged_ModelIsRemoved_ViewModelIsRemoved(bool isBulk, bool isConcurrent)
         {
             var dataSource =
                 new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3) });
 
-            var wrappingCollection = new WrappingCollection(false, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
+            var wrappingCollection = new WrappingCollection(isBulk, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
             wrappingCollection.AddSource(dataSource);
             dataSource.Remove(dataSource.Last());
 
@@ -42,14 +46,16 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void DataSourceCollectionChanged_DataSourceIsCleared_ViewModelsAreCleared(bool isConcurrent)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void DataSourceCollectionChanged_DataSourceIsCleared_ViewModelsAreCleared(bool isBulk, bool isConcurrent)
         {
             var dataSource =
                 new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3) });
 
-            var wrappingCollection = new WrappingCollection(false, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
+            var wrappingCollection = new WrappingCollection(isBulk, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
             wrappingCollection.AddSource(dataSource);
             dataSource.Clear();
 
@@ -58,15 +64,17 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void DataSourcesCollectionChanged_DataSourceIsAdded_ViewModelsAreAdded(bool isConcurrent)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void DataSourcesCollectionChanged_DataSourceIsAdded_ViewModelsAreAdded(bool isBulk, bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3) });
             var anotherDataSource = new ObservableCollection<TestModel>(new[] {new TestModel(5), new TestModel(6)});
 
-            var wrappingCollection = new WrappingCollection(false, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
+            var wrappingCollection = new WrappingCollection(isBulk, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
             wrappingCollection.AddSource(originalDataSource);
             wrappingCollection.AddSource(anotherDataSource);
 
@@ -76,14 +84,16 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void DataSourcesCollectionChanged_DataSourceIsRemoved_ViewModelsAreRemoved(bool isConcurrent)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void DataSourcesCollectionChanged_DataSourceIsRemoved_ViewModelsAreRemoved(bool isBulk, bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3) });            
 
-            var wrappingCollection = new WrappingCollection(false, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
+            var wrappingCollection = new WrappingCollection(isBulk, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
             wrappingCollection.AddSource(originalDataSource);
             wrappingCollection.RemoveSource(originalDataSource);
 
@@ -91,14 +101,16 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void DataSourcesCollectionChanged_DataSourcesAreCleared_ViewModelsAreRemoved(bool isConcurrent)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void DataSourcesCollectionChanged_DataSourcesAreCleared_ViewModelsAreRemoved(bool isBulk, bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3) });
 
-            var wrappingCollection = new WrappingCollection(false, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
+            var wrappingCollection = new WrappingCollection(isBulk, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
             wrappingCollection.AddSource(originalDataSource);
             wrappingCollection.ClearSources();
 
@@ -106,16 +118,18 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void DataSourcesCollectionChanged_DataSourceIsAddedThenAllModelsAreRemovedThenModelIsAdded_ViewModelIsAdded(bool isConcurrent)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void DataSourcesCollectionChanged_DataSourceIsAddedThenAllModelsAreRemovedThenModelIsAdded_ViewModelIsAdded(bool isBulk, bool isConcurrent)
         {
             var models = new[] { new TestModel(1), new TestModel(2), new TestModel(3)};
             var newModel = new TestModel(4);
             var originalDataSource =
                 new ObservableCollection<TestModel>(models);            
 
-            var wrappingCollection = new WrappingCollection(false, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
+            var wrappingCollection = new WrappingCollection(isBulk, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
             wrappingCollection.AddSource(originalDataSource);
             originalDataSource.Remove(models[0]);
             originalDataSource.Remove(models[1]);

--- a/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/DataSourceCollectionChangedTests.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/DataSourceCollectionChangedTests.cs
@@ -7,13 +7,15 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
 {        
     public class DataSourceCollectionChangedTests : WrappingCollectionTestsBase
     {
-        [Fact]
-        public void DataSourceCollectionChanged_ModelIsAdded_ViewModelIsAdded()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataSourceCollectionChanged_ModelIsAdded_ViewModelIsAdded(bool isConcurrent)
         {
             var dataSource =
                 new ObservableCollection<TestModel>(new[] {new TestModel(1), new TestModel(2), new TestModel(3)});
 
-            var wrappingCollection = new WrappingCollection {FactoryMethod = o => new TestViewModel((TestModel)o)};
+            var wrappingCollection = new WrappingCollection(false, isConcurrent) {FactoryMethod = o => new TestViewModel((TestModel)o)};
             wrappingCollection.AddSource(dataSource);
             dataSource.Add(new TestModel(4));
 
@@ -22,13 +24,15 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
             actualViewModel.Should().NotBeNull();            
         }
 
-        [Fact]
-        public void DataSourceCollectionChanged_ModelIsRemoved_ViewModelIsRemoved()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataSourceCollectionChanged_ModelIsRemoved_ViewModelIsRemoved(bool isConcurrent)
         {
             var dataSource =
                 new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3) });
 
-            var wrappingCollection = new WrappingCollection { FactoryMethod = o => new TestViewModel((TestModel)o) };
+            var wrappingCollection = new WrappingCollection(false, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
             wrappingCollection.AddSource(dataSource);
             dataSource.Remove(dataSource.Last());
 
@@ -37,13 +41,15 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
             actualViewModel.Should().BeNull();           
         }
 
-        [Fact]
-        public void DataSourceCollectionChanged_DataSourceIsCleared_ViewModelsAreCleared()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataSourceCollectionChanged_DataSourceIsCleared_ViewModelsAreCleared(bool isConcurrent)
         {
             var dataSource =
                 new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3) });
 
-            var wrappingCollection = new WrappingCollection { FactoryMethod = o => new TestViewModel((TestModel)o) };
+            var wrappingCollection = new WrappingCollection(false, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
             wrappingCollection.AddSource(dataSource);
             dataSource.Clear();
 
@@ -51,14 +57,16 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
             viewModels.Should().BeEmpty();            
         }
 
-        [Fact]
-        public void DataSourcesCollectionChanged_DataSourceIsAdded_ViewModelsAreAdded()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataSourcesCollectionChanged_DataSourceIsAdded_ViewModelsAreAdded(bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3) });
             var anotherDataSource = new ObservableCollection<TestModel>(new[] {new TestModel(5), new TestModel(6)});
 
-            var wrappingCollection = new WrappingCollection { FactoryMethod = o => new TestViewModel((TestModel)o) };
+            var wrappingCollection = new WrappingCollection(false, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
             wrappingCollection.AddSource(originalDataSource);
             wrappingCollection.AddSource(anotherDataSource);
 
@@ -67,41 +75,47 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
             wrappingCollection.OfType<TestViewModel>().Select(t => t.Model).Should().BeEquivalentTo(expectedModels);            
         }
 
-        [Fact]
-        public void DataSourcesCollectionChanged_DataSourceIsRemoved_ViewModelsAreRemoved()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataSourcesCollectionChanged_DataSourceIsRemoved_ViewModelsAreRemoved(bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3) });            
 
-            var wrappingCollection = new WrappingCollection { FactoryMethod = o => new TestViewModel((TestModel)o) };
+            var wrappingCollection = new WrappingCollection(false, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
             wrappingCollection.AddSource(originalDataSource);
             wrappingCollection.RemoveSource(originalDataSource);
 
             wrappingCollection.Should().BeEmpty();            
         }
 
-        [Fact]
-        public void DataSourcesCollectionChanged_DataSourcesAreCleared_ViewModelsAreRemoved()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataSourcesCollectionChanged_DataSourcesAreCleared_ViewModelsAreRemoved(bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3) });
 
-            var wrappingCollection = new WrappingCollection { FactoryMethod = o => new TestViewModel((TestModel)o) };
+            var wrappingCollection = new WrappingCollection(false, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
             wrappingCollection.AddSource(originalDataSource);
             wrappingCollection.ClearSources();
 
             wrappingCollection.Should().BeEmpty();
         }
 
-        [Fact]
-        public void DataSourcesCollectionChanged_DataSourceIsAddedThenAllModelsAreRemovedThenModelIsAdded_ViewModelIsAdded()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void DataSourcesCollectionChanged_DataSourceIsAddedThenAllModelsAreRemovedThenModelIsAdded_ViewModelIsAdded(bool isConcurrent)
         {
             var models = new[] { new TestModel(1), new TestModel(2), new TestModel(3)};
             var newModel = new TestModel(4);
             var originalDataSource =
                 new ObservableCollection<TestModel>(models);            
 
-            var wrappingCollection = new WrappingCollection { FactoryMethod = o => new TestViewModel((TestModel)o) };
+            var wrappingCollection = new WrappingCollection(false, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
             wrappingCollection.AddSource(originalDataSource);
             originalDataSource.Remove(models[0]);
             originalDataSource.Remove(models[1]);

--- a/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/DataSourceModificationsTests.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/DataSourceModificationsTests.cs
@@ -8,15 +8,17 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
     public class DataSourceModificationsTests : WrappingCollectionTestsBase
     {
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void ModelIsAddedThenModelIsRemovedThenModelIsAdded(bool isConcurrent)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void ModelIsAddedThenModelIsRemovedThenModelIsAdded(bool isBulk, bool isConcurrent)
         {
             var firstModel = new TestModel(1);
             var dataSource =
                 new ObservableCollection<TestModel>(new[] { firstModel });
 
-            var wrappingCollection = new WrappingCollection(false, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
+            var wrappingCollection = new WrappingCollection(isBulk, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
             wrappingCollection.AddSource(dataSource);
             dataSource.Remove(firstModel);
             dataSource.Add(firstModel);

--- a/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/DataSourceModificationsTests.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/DataSourceModificationsTests.cs
@@ -7,14 +7,16 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
 {    
     public class DataSourceModificationsTests : WrappingCollectionTestsBase
     {
-        [Fact]
-        public void ModelIsAddedThenModelIsRemovedThenModelIsAdded()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ModelIsAddedThenModelIsRemovedThenModelIsAdded(bool isConcurrent)
         {
             var firstModel = new TestModel(1);
             var dataSource =
                 new ObservableCollection<TestModel>(new[] { firstModel });
 
-            var wrappingCollection = new WrappingCollection { FactoryMethod = o => new TestViewModel((TestModel)o) };
+            var wrappingCollection = new WrappingCollection(false, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
             wrappingCollection.AddSource(dataSource);
             dataSource.Remove(firstModel);
             dataSource.Add(firstModel);

--- a/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/InitializationTests.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/InitializationTests.cs
@@ -8,13 +8,15 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
     public class InitializationTests : WrappingCollectionTestsBase
     {
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void AddingDataSource_DataSourceContainsModelsAndFactoryMethodIsSpecified_CollectionContainsConcreteTypeViewModelsWithDataSourceModels(bool isConcurrent)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void AddingDataSource_DataSourceContainsModelsAndFactoryMethodIsSpecified_CollectionContainsConcreteTypeViewModelsWithDataSourceModels(bool isBulk, bool isConcurrent)
         {
             var dataSource = new[] {new TestModel(1), new TestModel(2), new TestModel(3)};
 
-            var wrappingCollection = new WrappingCollection(false, isConcurrent) {FactoryMethod = o => new TestViewModel((TestModel)o)};
+            var wrappingCollection = new WrappingCollection(isBulk, isConcurrent) {FactoryMethod = o => new TestViewModel((TestModel)o)};
             wrappingCollection.AddSource(dataSource);
 
             var viewModels = wrappingCollection.OfType<TestViewModel>().ToArray();
@@ -23,13 +25,15 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void AddingDataSource_DataSourceContainsModelsAndFactoryMethodIsNotSpecified_CollectionContainsViewModelsWithDataSourceModels(bool isConcurrent)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void AddingDataSource_DataSourceContainsModelsAndFactoryMethodIsNotSpecified_CollectionContainsViewModelsWithDataSourceModels(bool isBulk, bool isConcurrent)
         {
             var dataSource = new[] { new TestModel(1), new TestModel(2), new TestModel(3) };
 
-            var wrappingCollection = new WrappingCollection(false, isConcurrent);
+            var wrappingCollection = new WrappingCollection(isBulk, isConcurrent);
             wrappingCollection.AddSource(dataSource);
 
             var viewModels = wrappingCollection.OfType<object>().ToArray();
@@ -40,13 +44,15 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void AddingDataSource_DataSourceContainsModelsAndSelectionModeIsOne_FirstViewModelIsSelected(bool isConcurrent)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void AddingDataSource_DataSourceContainsModelsAndSelectionModeIsOne_FirstViewModelIsSelected(bool isBulk, bool isConcurrent)
         {
             var dataSource = new[] { new TestModel(1), new TestModel(2), new TestModel(3) };
 
-            var wrappingCollection = new WrappingCollection.WithSelection(SelectionMode.One, false, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
+            var wrappingCollection = new WrappingCollection.WithSelection(SelectionMode.One, isBulk, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
             wrappingCollection.AddSource(dataSource);
 
             var viewModels = wrappingCollection.OfType<TestViewModel>().ToArray();
@@ -56,13 +62,15 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void AddingDataSource_DataSourceContainsModelsAndSelectionModeIsZeroOrMore_NoViewModelIsSelected(bool isConcurrent)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void AddingDataSource_DataSourceContainsModelsAndSelectionModeIsZeroOrMore_NoViewModelIsSelected(bool isBulk, bool isConcurrent)
         {
             var dataSource = new[] { new TestModel(1), new TestModel(2), new TestModel(3) };
 
-            var wrappingCollection = new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore, false, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
+            var wrappingCollection = new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore, isBulk, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
             wrappingCollection.AddSource(dataSource);
             
             var selectedViewModel = wrappingCollection.SelectedItem;

--- a/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/InitializationTests.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/InitializationTests.cs
@@ -6,13 +6,15 @@ using Xunit;
 namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
 {    
     public class InitializationTests : WrappingCollectionTestsBase
-    {        
-        [Fact]
-        public void AddingDataSource_DataSourceContainsModelsAndFactoryMethodIsSpecified_CollectionContainsConcreteTypeViewModelsWithDataSourceModels()
+    {
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AddingDataSource_DataSourceContainsModelsAndFactoryMethodIsSpecified_CollectionContainsConcreteTypeViewModelsWithDataSourceModels(bool isConcurrent)
         {
             var dataSource = new[] {new TestModel(1), new TestModel(2), new TestModel(3)};
 
-            var wrappingCollection = new WrappingCollection {FactoryMethod = o => new TestViewModel((TestModel)o)};
+            var wrappingCollection = new WrappingCollection(false, isConcurrent) {FactoryMethod = o => new TestViewModel((TestModel)o)};
             wrappingCollection.AddSource(dataSource);
 
             var viewModels = wrappingCollection.OfType<TestViewModel>().ToArray();
@@ -20,12 +22,14 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
             actualModels.Should().BeEquivalentTo(dataSource);
         }
 
-        [Fact]
-        public void AddingDataSource_DataSourceContainsModelsAndFactoryMethodIsNotSpecified_CollectionContainsViewModelsWithDataSourceModels()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AddingDataSource_DataSourceContainsModelsAndFactoryMethodIsNotSpecified_CollectionContainsViewModelsWithDataSourceModels(bool isConcurrent)
         {
             var dataSource = new[] { new TestModel(1), new TestModel(2), new TestModel(3) };
 
-            var wrappingCollection = new WrappingCollection();
+            var wrappingCollection = new WrappingCollection(false, isConcurrent);
             wrappingCollection.AddSource(dataSource);
 
             var viewModels = wrappingCollection.OfType<object>().ToArray();
@@ -35,12 +39,14 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
             actualModels.Should().BeEquivalentTo(dataSource);
         }
 
-        [Fact]
-        public void AddingDataSource_DataSourceContainsModelsAndSelectionModeIsOne_FirstViewModelIsSelected()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AddingDataSource_DataSourceContainsModelsAndSelectionModeIsOne_FirstViewModelIsSelected(bool isConcurrent)
         {
             var dataSource = new[] { new TestModel(1), new TestModel(2), new TestModel(3) };
 
-            var wrappingCollection = new WrappingCollection.WithSelection(SelectionMode.One) { FactoryMethod = o => new TestViewModel((TestModel)o) };
+            var wrappingCollection = new WrappingCollection.WithSelection(SelectionMode.One, false, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
             wrappingCollection.AddSource(dataSource);
 
             var viewModels = wrappingCollection.OfType<TestViewModel>().ToArray();
@@ -49,12 +55,14 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
             selectedViewModel.Should().BeSameAs(firstViewModel);            
         }
 
-        [Fact]
-        public void AddingDataSource_DataSourceContainsModelsAndSelectionModeIsZeroOrMore_NoViewModelIsSelected()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AddingDataSource_DataSourceContainsModelsAndSelectionModeIsZeroOrMore_NoViewModelIsSelected(bool isConcurrent)
         {
             var dataSource = new[] { new TestModel(1), new TestModel(2), new TestModel(3) };
 
-            var wrappingCollection = new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore) { FactoryMethod = o => new TestViewModel((TestModel)o) };
+            var wrappingCollection = new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore, false, isConcurrent) { FactoryMethod = o => new TestViewModel((TestModel)o) };
             wrappingCollection.AddSource(dataSource);
             
             var selectedViewModel = wrappingCollection.SelectedItem;

--- a/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/NotificationTests.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/NotificationTests.cs
@@ -7,16 +7,18 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
 {    
     public class NotificationTests : WrappingCollectionTestsBase
     {
-        [Fact]
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public void
             WhenCollectionIsCreatedWithRangeAndSourceIsUpdatedWithAddRange_ThenSingleNotificationIsRaisedWithAllWrappers
-            ()
+            (bool isConcurrent)
         {
             var source = new RangeObservableCollection<object>();
             var items = new[] { new object(), new object() };
             var numberOfTimes = 0;
 
-            var collection = new WrappingCollection(isBulk: true)
+            var collection = new WrappingCollection(true, isConcurrent)
             {
                 FactoryMethod = o => o
             };
@@ -30,16 +32,18 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
             source.AddRange(items);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public void
             WhenCollectionIsCreatedWithRangeAndSingleItemAndSourceIsUpdatedWithRemoveRange_ThenSingleNotificationIsRaisedWithAllWrappers
-            ()
+            (bool isConcurrent)
         {
             var source = new RangeObservableCollection<object>();
             var items = new[] { new object() };
             var numberOfTimes = 0;
 
-            var collection = new WrappingCollection(isBulk: true)
+            var collection = new WrappingCollection(true, isConcurrent)
             {
                 FactoryMethod = o => o
             };
@@ -54,16 +58,18 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
             source.RemoveRange(items);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public void
             WhenCollectionIsCreatedWithRangeAndMultipleItemsAndSourceIsUpdatedWithRemoveRange_ThenSingleNotificationIsRaisedWithAllWrappersAndActionIsReset
-            ()
+            (bool isConcurrent)
         {
             var source = new RangeObservableCollection<object>();
             var items = new[] { new object(), new object(), new object() };
             var numberOfTimes = 0;
 
-            var collection = new WrappingCollection(isBulk: true)
+            var collection = new WrappingCollection(true, isConcurrent)
             {
                 FactoryMethod = o => o
             };
@@ -78,16 +84,18 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
             source.RemoveRange(items);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public void
             WhenCollectionIsCreatedWithRangeAndSingleItemAndSourceIsCleared_ThenSingleNotificationIsRaisedWithAllWrappers
-            ()
+            (bool isConcurrent)
         {
             var source = new RangeObservableCollection<object>();
             var items = new[] { new object() };
             var numberOfTimes = 0;
 
-            var collection = new WrappingCollection(isBulk: true)
+            var collection = new WrappingCollection(true, isConcurrent)
             {
                 FactoryMethod = o => o
             };
@@ -102,16 +110,18 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
             source.Clear();
         }
 
-        [Fact]
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public void
             WhenCollectionIsCreatedWithRangeAndMultipleItemsAndSourceIsCleared_ThenSingleNotificationIsRaisedWithAllWrappersAndActionisReset
-            ()
+            (bool isConcurrent)
         {
             var source = new RangeObservableCollection<object>();
             var items = new[] { new object(), new object(), new object() };
             var numberOfTimes = 0;
 
-            var collection = new WrappingCollection(isBulk: true)
+            var collection = new WrappingCollection(true, isConcurrent)
             {
                 FactoryMethod = o => o
             };

--- a/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/SelectionTests.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/SelectionTests.cs
@@ -9,30 +9,36 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
 {        
     public class SelectionTests : WrappingCollectionTestsBase
     {
-        [Fact]
-        public void Selection_ItemIsSelectedAndDeselected_SelectionIsEmpty()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Selection_ItemIsSelectedAndDeselected_SelectionIsEmpty(bool isConcurrent)
         {
             var originalDataSource =
-                new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3) });
+                new ObservableCollection<TestModel>(new[] {new TestModel(1), new TestModel(2), new TestModel(3)});
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection {FactoryMethod = o => new TestViewModel((TestModel) o)}.WithSource(
+                new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore, false, isConcurrent)
+                    {FactoryMethod = o => new TestViewModel((TestModel) o)}.WithSource(
                     originalDataSource);
             var firstItem = wrappingCollection.OfType<TestViewModel>().First();
             wrappingCollection.Select(firstItem);
             wrappingCollection.Unselect(firstItem);
 
-            AssertEmptySelection(wrappingCollection);            
+            AssertEmptySelection(wrappingCollection);
         }
 
-        [Fact]
-        public void Selection_SelectionModeIsMultipleItemIsSelectedAndAnotherItemIsSelected_BothItemsAreSelected()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Selection_SelectionModeIsMultipleItemIsSelectedAndAnotherItemIsSelected_BothItemsAreSelected(
+            bool isConcurrent)
         {
             var originalDataSource =
-                new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3) });
+                new ObservableCollection<TestModel>(new[] {new TestModel(1), new TestModel(2), new TestModel(3)});
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore)
+                new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore, false, isConcurrent)
                 {
                     FactoryMethod = o => new TestViewModel((TestModel) o)
                 }.WithSource(originalDataSource);
@@ -44,17 +50,20 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
             wrappingCollection.SelectedItem.Should().Be(firstItem);
             var expectedSelection = new[] {firstItem, secondItem};
             wrappingCollection.SelectedItems.Should().BeEquivalentTo(expectedSelection);
-            wrappingCollection.SelectionCount.Should().Be(2);            
+            wrappingCollection.SelectionCount.Should().Be(2);
         }
 
-        //TODO: causing stack overflow - check after model package update  
-        [Fact]
-        void Selection_SelectionModeIsSingleItemIsSelectedAndAnotherItemIsSelected_OnlySecondItemIsSelected()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Selection_SelectionModeIsSingleItemIsSelectedAndAnotherItemIsSelected_OnlySecondItemIsSelected(
+            bool isConcurrent)
         {
             var originalDataSource =
-                new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3) });
+                new ObservableCollection<TestModel>(new[] {new TestModel(1), new TestModel(2), new TestModel(3)});
 
-            var wrappingCollection = new WrappingCollection.WithSelection(SelectionMode.One) { FactoryMethod = o => new TestViewModel((TestModel)o) };
+            var wrappingCollection = new WrappingCollection.WithSelection(SelectionMode.One, false, isConcurrent)
+                {FactoryMethod = o => new TestViewModel((TestModel) o)};
             wrappingCollection.AddSource(originalDataSource);
             var firstItem = wrappingCollection.OfType<TestViewModel>().First();
             var secondItem = wrappingCollection.OfType<TestViewModel>().Skip(1).First();
@@ -62,55 +71,61 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
             wrappingCollection.Select(secondItem);
 
             wrappingCollection.SelectedItem.Should().Be(secondItem);
-            var expectedSelection = new[] { secondItem };
+            var expectedSelection = new[] {secondItem};
             wrappingCollection.SelectedItems.Should().BeEquivalentTo(expectedSelection);
             wrappingCollection.SelectionCount.Should().Be(1);
         }
 
-        [Fact]
-        public void Selection_ItemIsSelectedThenItemIsRemoved_SelectionIsEmpty()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Selection_ItemIsSelectedThenItemIsRemoved_SelectionIsEmpty(bool isConcurrent)
         {
             var originalDataSource =
-                new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3) });
+                new ObservableCollection<TestModel>(new[] {new TestModel(1), new TestModel(2), new TestModel(3)});
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore)
+                new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore, false, isConcurrent)
                 {
                     FactoryMethod = o => new TestViewModel((TestModel) o)
                 }.WithSource(originalDataSource);
-            var firstItem = wrappingCollection.OfType<TestViewModel>().First();            
+            var firstItem = wrappingCollection.OfType<TestViewModel>().First();
             wrappingCollection.Select(firstItem);
             originalDataSource.RemoveAt(0);
 
             AssertEmptySelection(wrappingCollection);
-        }        
+        }
 
-        [Fact]
-        public void Selection_ItemIsSelectedThenAllItemsAreRemoved_SelectionIsEmpty()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Selection_ItemIsSelectedThenAllItemsAreRemoved_SelectionIsEmpty(bool isConcurrent)
         {
             var originalDataSource =
-                new RangeObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3) });
+                new RangeObservableCollection<TestModel>(new[] {new TestModel(1), new TestModel(2), new TestModel(3)});
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore)
+                new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore, false, isConcurrent)
                 {
                     FactoryMethod = o => new TestViewModel((TestModel) o)
                 }.WithSource(originalDataSource);
-            var firstItem = wrappingCollection.OfType<TestViewModel>().First();            
+            var firstItem = wrappingCollection.OfType<TestViewModel>().First();
             wrappingCollection.Select(firstItem);
             originalDataSource.RemoveRange(originalDataSource.ToArray());
 
             AssertEmptySelection(wrappingCollection);
-        }        
+        }
 
-        [Fact]
-        public void ClearSelection_CollectionContainsTwoSelectedItems_SelectionIsEmpty()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ClearSelection_CollectionContainsTwoSelectedItems_SelectionIsEmpty(bool isConcurrent)
         {
             var originalDataSource =
-                            new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3) });
+                new ObservableCollection<TestModel>(new[] {new TestModel(1), new TestModel(2), new TestModel(3)});
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore)
+                new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore, false, isConcurrent)
                 {
                     FactoryMethod = o => new TestViewModel((TestModel) o)
                 }.WithSource(originalDataSource);
@@ -123,14 +138,16 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
             AssertEmptySelection(wrappingCollection);
         }
 
-        [Fact]
-        public void CollectionIsCreated_SelectionPredicateIsSetAndOriginalSourceContainsItemsThatMatchThePredicate_ItemsAreSelected()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CollectionIsCreated_SelectionPredicateIsSetAndOriginalSourceContainsItemsThatMatchThePredicate_ItemsAreSelected(bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3)});
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Id >= 2)
+                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Id >= 2, false, isConcurrent)
                 {
                     FactoryMethod = o => new TestViewModel((TestModel) o)
                 }.WithSource(originalDataSource);
@@ -142,14 +159,16 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
             wrappingCollection.SelectionCount.Should().Be(2);
         }
 
-        [Fact]
-        public void Select_SelectionPredicateIsSet_ExceptionIsThrown()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Select_SelectionPredicateIsSet_ExceptionIsThrown(bool isConcurrent)
         {
             var originalDataSource =
-                new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3) });
+                new ObservableCollection<TestModel>(new[] {new TestModel(1), new TestModel(2), new TestModel(3)});
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Id >= 2)
+                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Id >= 2, false, isConcurrent)
                 {
                     FactoryMethod = o => new TestViewModel((TestModel) o)
                 }.WithSource(originalDataSource);
@@ -159,14 +178,16 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
                 .Be("Explicit selection status change cannot be used together with selection predicate");
         }
 
-        [Fact]
-        public void Unselect_SelectionPredicateIsSet_ExceptionIsThrown()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void Unselect_SelectionPredicateIsSet_ExceptionIsThrown(bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3) });
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Id >= 2)
+                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Id >= 2, false, isConcurrent)
                 {
                     FactoryMethod = o => new TestViewModel((TestModel) o)
                 }.WithSource(originalDataSource);
@@ -176,8 +197,12 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
                 .Be("Explicit selection status change cannot be used together with selection predicate");
         }
 
-        [Fact]
-        public void ModelPropertyIsChanged_SelectionPredicateIsSetAndItemDoesntMatchPredicateAfterModelChange_ItemIsUnselected()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void
+            ModelPropertyIsChanged_SelectionPredicateIsSetAndItemDoesntMatchPredicateAfterModelChange_ItemIsUnselected(
+                bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[]
@@ -188,7 +213,8 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
                 });
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Name.Length <= 5)
+                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Name.Length <= 5, false,
+                    isConcurrent)
                 {
                     FactoryMethod = o => new TestViewModel((TestModel) o)
                 }.WithSource(originalDataSource);
@@ -197,14 +223,17 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
 
             var lastItem = wrappingCollection.OfType<TestViewModel>().Last();
             wrappingCollection.SelectedItem.Should().Be(lastItem);
-            var expectedSelection = new[] { lastItem };
+            var expectedSelection = new[] {lastItem};
             wrappingCollection.SelectedItems.Should().BeEquivalentTo(expectedSelection);
             wrappingCollection.SelectionCount.Should().Be(1);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
         public void
-            SelectionPredicateIsSet_SelectionPredicateWasSetInitiallyAndItemDoesnMatchTheNewPredicate_SelectionChanges()
+            SelectionPredicateIsSet_SelectionPredicateWasSetInitiallyAndItemDoesnMatchTheNewPredicate_SelectionChanges(
+                bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[]
@@ -215,15 +244,16 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
                 });
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Name.Length <= 5)
+                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Name.Length <= 5, false,
+                    isConcurrent)
                 {
                     FactoryMethod = o => new TestViewModel((TestModel) o)
                 }.WithSource(originalDataSource);
-            wrappingCollection.SelectionPredicate = wr => ((TestViewModel)wr).Model.Name.Length == 6;
+            wrappingCollection.SelectionPredicate = wr => ((TestViewModel) wr).Model.Name.Length == 6;
 
             var secondItem = wrappingCollection.OfType<TestViewModel>().ElementAt(1);
             wrappingCollection.SelectedItem.Should().Be(secondItem);
-            var expectedSelection = new[] { secondItem };
+            var expectedSelection = new[] {secondItem};
             wrappingCollection.SelectedItems.Should().BeEquivalentTo(expectedSelection);
             wrappingCollection.SelectionCount.Should().Be(1);
         }

--- a/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/SelectionTests.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel.Tests/WrappingCollectionTests/SelectionTests.cs
@@ -10,15 +10,17 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
     public class SelectionTests : WrappingCollectionTestsBase
     {
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Selection_ItemIsSelectedAndDeselected_SelectionIsEmpty(bool isConcurrent)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void Selection_ItemIsSelectedAndDeselected_SelectionIsEmpty(bool isBulk, bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[] {new TestModel(1), new TestModel(2), new TestModel(3)});
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore, false, isConcurrent)
+                new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore, isBulk, isConcurrent)
                     {FactoryMethod = o => new TestViewModel((TestModel) o)}.WithSource(
                     originalDataSource);
             var firstItem = wrappingCollection.OfType<TestViewModel>().First();
@@ -29,16 +31,18 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
         public void Selection_SelectionModeIsMultipleItemIsSelectedAndAnotherItemIsSelected_BothItemsAreSelected(
-            bool isConcurrent)
+            bool isBulk, bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[] {new TestModel(1), new TestModel(2), new TestModel(3)});
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore, false, isConcurrent)
+                new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore, isBulk, isConcurrent)
                 {
                     FactoryMethod = o => new TestViewModel((TestModel) o)
                 }.WithSource(originalDataSource);
@@ -54,15 +58,17 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
         public void Selection_SelectionModeIsSingleItemIsSelectedAndAnotherItemIsSelected_OnlySecondItemIsSelected(
-            bool isConcurrent)
+            bool isBulk, bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[] {new TestModel(1), new TestModel(2), new TestModel(3)});
 
-            var wrappingCollection = new WrappingCollection.WithSelection(SelectionMode.One, false, isConcurrent)
+            var wrappingCollection = new WrappingCollection.WithSelection(SelectionMode.One, isBulk, isConcurrent)
                 {FactoryMethod = o => new TestViewModel((TestModel) o)};
             wrappingCollection.AddSource(originalDataSource);
             var firstItem = wrappingCollection.OfType<TestViewModel>().First();
@@ -77,15 +83,17 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Selection_ItemIsSelectedThenItemIsRemoved_SelectionIsEmpty(bool isConcurrent)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void Selection_ItemIsSelectedThenItemIsRemoved_SelectionIsEmpty(bool isBulk, bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[] {new TestModel(1), new TestModel(2), new TestModel(3)});
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore, false, isConcurrent)
+                new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore, isBulk, isConcurrent)
                 {
                     FactoryMethod = o => new TestViewModel((TestModel) o)
                 }.WithSource(originalDataSource);
@@ -97,15 +105,17 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Selection_ItemIsSelectedThenAllItemsAreRemoved_SelectionIsEmpty(bool isConcurrent)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void Selection_ItemIsSelectedThenAllItemsAreRemoved_SelectionIsEmpty(bool isBulk, bool isConcurrent)
         {
             var originalDataSource =
                 new RangeObservableCollection<TestModel>(new[] {new TestModel(1), new TestModel(2), new TestModel(3)});
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore, false, isConcurrent)
+                new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore, isBulk, isConcurrent)
                 {
                     FactoryMethod = o => new TestViewModel((TestModel) o)
                 }.WithSource(originalDataSource);
@@ -117,15 +127,17 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void ClearSelection_CollectionContainsTwoSelectedItems_SelectionIsEmpty(bool isConcurrent)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void ClearSelection_CollectionContainsTwoSelectedItems_SelectionIsEmpty(bool isBulk, bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[] {new TestModel(1), new TestModel(2), new TestModel(3)});
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore, false, isConcurrent)
+                new WrappingCollection.WithSelection(SelectionMode.ZeroOrMore, isBulk, isConcurrent)
                 {
                     FactoryMethod = o => new TestViewModel((TestModel) o)
                 }.WithSource(originalDataSource);
@@ -139,15 +151,17 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void CollectionIsCreated_SelectionPredicateIsSetAndOriginalSourceContainsItemsThatMatchThePredicate_ItemsAreSelected(bool isConcurrent)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void CollectionIsCreated_SelectionPredicateIsSetAndOriginalSourceContainsItemsThatMatchThePredicate_ItemsAreSelected(bool isBulk, bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3)});
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Id >= 2, false, isConcurrent)
+                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Id >= 2, isBulk, isConcurrent)
                 {
                     FactoryMethod = o => new TestViewModel((TestModel) o)
                 }.WithSource(originalDataSource);
@@ -160,15 +174,17 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Select_SelectionPredicateIsSet_ExceptionIsThrown(bool isConcurrent)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void Select_SelectionPredicateIsSet_ExceptionIsThrown(bool isBulk, bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[] {new TestModel(1), new TestModel(2), new TestModel(3)});
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Id >= 2, false, isConcurrent)
+                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Id >= 2, isBulk, isConcurrent)
                 {
                     FactoryMethod = o => new TestViewModel((TestModel) o)
                 }.WithSource(originalDataSource);
@@ -179,15 +195,17 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public void Unselect_SelectionPredicateIsSet_ExceptionIsThrown(bool isConcurrent)
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
+        public void Unselect_SelectionPredicateIsSet_ExceptionIsThrown(bool isBulk, bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[] { new TestModel(1), new TestModel(2), new TestModel(3) });
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Id >= 2, false, isConcurrent)
+                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Id >= 2, isBulk, isConcurrent)
                 {
                     FactoryMethod = o => new TestViewModel((TestModel) o)
                 }.WithSource(originalDataSource);
@@ -198,11 +216,13 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
         public void
             ModelPropertyIsChanged_SelectionPredicateIsSetAndItemDoesntMatchPredicateAfterModelChange_ItemIsUnselected(
-                bool isConcurrent)
+                bool isBulk, bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[]
@@ -213,7 +233,7 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
                 });
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Name.Length <= 5, false,
+                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Name.Length <= 5, isBulk,
                     isConcurrent)
                 {
                     FactoryMethod = o => new TestViewModel((TestModel) o)
@@ -229,11 +249,13 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
         }
 
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
+        [InlineData(false, false)]
+        [InlineData(false, true)]
+        [InlineData(true, false)]
+        [InlineData(true, true)]
         public void
             SelectionPredicateIsSet_SelectionPredicateWasSetInitiallyAndItemDoesnMatchTheNewPredicate_SelectionChanges(
-                bool isConcurrent)
+                bool isBulk, bool isConcurrent)
         {
             var originalDataSource =
                 new ObservableCollection<TestModel>(new[]
@@ -244,7 +266,7 @@ namespace LogoFX.Client.Mvvm.ViewModel.Tests.WrappingCollectionTests
                 });
 
             var wrappingCollection =
-                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Name.Length <= 5, false,
+                new WrappingCollection.WithSelection(wr => ((TestViewModel) wr).Model.Name.Length <= 5, isBulk,
                     isConcurrent)
                 {
                     FactoryMethod = o => new TestViewModel((TestModel) o)

--- a/src/LogoFX.Client.Mvvm.ViewModel/IIndexedDictionary.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel/IIndexedDictionary.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace LogoFX.Client.Mvvm.ViewModel
 {
-    public interface IIndexedDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+    interface IIndexedDictionary<TKey, TValue> : IDictionary<TKey, TValue>
     {        
         void AddAt(int index, TKey key, TValue item);                
     }

--- a/src/LogoFX.Client.Mvvm.ViewModel/IIndexedDictionary.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel/IIndexedDictionary.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace LogoFX.Client.Mvvm.ViewModel
+{
+    public interface IIndexedDictionary<TKey, TValue> : IDictionary<TKey, TValue>
+    {        
+        void AddAt(int index, TKey key, TValue item);                
+    }
+
+    interface IIndexedDictionaryFactory
+    {
+        IIndexedDictionary<TKey, TValue> Create<TKey, TValue>();
+    }
+
+    class RegularIndexedDictionaryFactory : IIndexedDictionaryFactory
+    {
+        public IIndexedDictionary<TKey, TValue> Create<TKey, TValue>()
+        {
+            return new WrappingCollection.IndexedDictionary<TKey, TValue>();
+        }
+    }
+
+    class ConcurrentIndexedDictionaryFactory : IIndexedDictionaryFactory
+    {
+        public IIndexedDictionary<TKey, TValue> Create<TKey, TValue>()
+        {
+            return new WrappingCollection.ConcurrentIndexedDictionary<TKey, TValue>();
+        }
+    }
+}

--- a/src/LogoFX.Client.Mvvm.ViewModel/SelectionSetupOptions.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel/SelectionSetupOptions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+
+namespace LogoFX.Client.Mvvm.ViewModel
+{
+    public class SelectionSetupOptions : SetupOptions
+    {
+        private const SelectionMode DefaultSelectionMode = SelectionMode.ZeroOrMore;
+        public SelectionMode SelectionMode { get; private set; } = DefaultSelectionMode;
+        public Predicate<object> SelectionPredicate { get; private set; }       
+
+        public SelectionSetupOptions UseSelectionMode(SelectionMode selectionMode)
+        {
+            SelectionMode = selectionMode;
+            return this;
+        }
+
+        public SelectionSetupOptions UseSelectionPredicate(Predicate<object> selectionPredicate)
+        {
+            SelectionPredicate = selectionPredicate;
+            return this;
+        }
+
+        public new SelectionSetupOptions UseBulk()
+        {
+            base.UseBulk();
+            return this;
+        }
+
+        public new SelectionSetupOptions UseConcurrent()
+        {
+            base.UseConcurrent();
+            return this;
+        }
+    }
+}

--- a/src/LogoFX.Client.Mvvm.ViewModel/SelectionSetupOptions.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel/SelectionSetupOptions.cs
@@ -2,30 +2,51 @@
 
 namespace LogoFX.Client.Mvvm.ViewModel
 {
+    /// <summary>
+    /// Represents setup options for <see cref="WrappingCollection.WithSelection"/>
+    /// </summary>
     public class SelectionSetupOptions : SetupOptions
     {
         private const SelectionMode DefaultSelectionMode = SelectionMode.ZeroOrMore;
         public SelectionMode SelectionMode { get; private set; } = DefaultSelectionMode;
         public Predicate<object> SelectionPredicate { get; private set; }       
 
+        /// <summary>
+        /// Configures the setup to use the provided selection mode.
+        /// </summary>
+        /// <param name="selectionMode">The selection mode.</param>
+        /// <returns></returns>
         public SelectionSetupOptions UseSelectionMode(SelectionMode selectionMode)
         {
             SelectionMode = selectionMode;
             return this;
         }
 
+        /// <summary>
+        /// Configures the setup to use the provided selection predicate.
+        /// </summary>
+        /// <param name="selectionPredicate">The selection predicate.</param>
+        /// <returns></returns>
         public SelectionSetupOptions UseSelectionPredicate(Predicate<object> selectionPredicate)
         {
             SelectionPredicate = selectionPredicate;
             return this;
         }
 
+        /// <summary>
+        /// Configures the setup to use bulk mode.
+        /// </summary>
+        /// <returns></returns>
         public new SelectionSetupOptions UseBulk()
         {
             base.UseBulk();
             return this;
         }
 
+        /// <summary>
+        /// Configures the setup to use concurrent data structures.
+        /// </summary>
+        /// <returns></returns>
         public new SelectionSetupOptions UseConcurrent()
         {
             base.UseConcurrent();

--- a/src/LogoFX.Client.Mvvm.ViewModel/SetupOptions.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel/SetupOptions.cs
@@ -1,16 +1,27 @@
 ﻿namespace LogoFX.Client.Mvvm.ViewModel
 {
+    /// <summary>
+    /// Represents setup options for <see cref="WrappingCollection"/>
+    /// </summary>
     public class SetupOptions
     {
         public bool IsBulk { get; protected set; }
         public bool IsConcurrent { get; protected set; }
 
+        /// <summary>
+        /// Configures the setup to use bulk mode.
+        /// </summary>
+        /// <returns></returns>
         public SetupOptions UseBulk()
         {
             IsBulk = true;
             return this;
         }
 
+        /// <summary>
+        /// Configures the setup to use concurrent data structures.
+        /// </summary>
+        /// <returns></returns>
         public SetupOptions UseConcurrent()
         {
             IsConcurrent = true;

--- a/src/LogoFX.Client.Mvvm.ViewModel/SetupOptions.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel/SetupOptions.cs
@@ -1,0 +1,20 @@
+﻿namespace LogoFX.Client.Mvvm.ViewModel
+{
+    public class SetupOptions
+    {
+        public bool IsBulk { get; protected set; }
+        public bool IsConcurrent { get; protected set; }
+
+        public SetupOptions UseBulk()
+        {
+            IsBulk = true;
+            return this;
+        }
+
+        public SetupOptions UseConcurrent()
+        {
+            IsConcurrent = true;
+            return this;
+        }
+    }
+}

--- a/src/LogoFX.Client.Mvvm.ViewModel/WrappingCollection.IndexedDictionary.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel/WrappingCollection.IndexedDictionary.cs
@@ -352,7 +352,7 @@ namespace LogoFX.Client.Mvvm.ViewModel
                 return base.ContainsKey(TransformKey(key));
             }
 
-            public new virtual void Add(TKey key, TValue item)
+            public virtual void Add(TKey key, TValue item)
             {
                 AddAt(-1, key, item);
             }
@@ -403,7 +403,7 @@ namespace LogoFX.Client.Mvvm.ViewModel
                 Remove(TransformKey(key));
             }
 
-            public new void Remove(TKey key)
+            public void Remove(TKey key)
             {
                 bool bContains = ContainsKey(TransformKey(key));
                 if (m_bThrowErrorOnInvalidRemove && !bContains)

--- a/src/LogoFX.Client.Mvvm.ViewModel/WrappingCollection.IndexedDictionary.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel/WrappingCollection.IndexedDictionary.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace LogoFX.Client.Mvvm.ViewModel
@@ -10,7 +11,7 @@ namespace LogoFX.Client.Mvvm.ViewModel
         /// </summary>
         /// <typeparam name="TKey">type for the key</typeparam>
         /// <typeparam name="TValue">type for the value</typeparam>
-        internal class IndexedDictionary<TKey, TValue> : Dictionary<TKey, TValue>
+        internal class IndexedDictionary<TKey, TValue> : Dictionary<TKey, TValue>, IIndexedDictionary<TKey, TValue>
         {
             #region Private variables
 
@@ -173,6 +174,273 @@ namespace LogoFX.Client.Mvvm.ViewModel
                 {
                     AfterRemove.Invoke(this, e);
                 }
+            }
+
+            public TKey GetKeyByIndex(int index)
+            {
+                return m_col[index];
+            }
+
+            public new bool ContainsKey(TKey key)
+            {
+                return base.ContainsKey(TransformKey(key));
+            }
+
+            /// <summary>
+            /// Clears all values and raises events.
+            /// </summary>
+            public new void Clear()
+            {
+                DictionaryBeforeClearEventArgs e = new DictionaryBeforeClearEventArgs();
+
+                // Raise before events:
+                bool bubble = true;
+                if (BeforeClear != null)
+                {
+                    foreach (DictionaryBeforeClearDelegate function in BeforeClear.GetInvocationList())
+                    {
+                        e.Bubble = true;
+                        function.Invoke(this, e);
+                        bubble = bubble && e.Bubble;
+                    }
+                }
+                if (!bubble) return;
+
+                // Clear items item:
+                base.Clear();
+                m_col.Clear();
+
+                // Raise after events:
+                if (AfterClear != null)
+                {
+                    AfterClear.Invoke(this, new EventArgs());
+                }
+            }
+
+            /// <summary>
+            /// Searches for a key that matches the conditions defined by the specified predicate, and returnes a zero-based index of the first occurrence in the list of keys.
+            /// </summary>
+            /// <returns></returns>
+            public int IndexOfKey(TKey key)
+            {
+                return m_col.IndexOf(key);
+            }
+
+            #endregion
+
+            #region Indexers
+
+            public new TValue this[TKey key]
+            {
+                get { return base[TransformKey(key)]; }
+                set
+                {
+                    if (!base.ContainsKey(TransformKey(key)))
+                    {
+                        throw new IndexedDictionaryException(
+                            "Values cannot be added directly. Use Add() or AddAt() method.");
+                    }
+                    base[TransformKey(key)] = value;
+                }
+            }
+
+
+            public TValue this[int index]
+            {
+                get { return this[m_col[index]]; }
+                set { this[m_col[index]] = value; }
+            }
+
+            #endregion
+
+            #region Events
+
+            public event DictionaryBeforeDelegate<TKey, TValue> BeforeAdd;
+
+            public event DictionaryBeforeDelegate<TKey, TValue> BeforeRemove;
+
+            public event DictionaryAfterDelegate<TKey, TValue> AfterAdd;
+
+            public event DictionaryAfterDelegate<TKey, TValue> AfterRemove;
+
+            public event DictionaryBeforeClearDelegate BeforeClear;
+
+            public event DictionaryAfterClearDelegate AfterClear;
+
+            #endregion
+        }
+
+        /// <summary>
+        /// An indexable Dictionary
+        /// </summary>
+        /// <typeparam name="TKey">type for the key</typeparam>
+        /// <typeparam name="TValue">type for the value</typeparam>
+        internal class ConcurrentIndexedDictionary<TKey, TValue> : ConcurrentDictionary<TKey, TValue>, IIndexedDictionary<TKey, TValue>
+        {
+            #region Private variables
+
+            protected List<TKey> m_col = new List<TKey>();
+            protected bool m_bReplaceDuplicateKeys = false; //can key be inserted more than once?
+            //if so then it will if it contains the key on add
+
+            protected bool m_bThrowErrorOnInvalidRemove = false; //if true then throws an exception if the 
+
+            #endregion
+
+            #region Contructors
+
+            public ConcurrentIndexedDictionary()
+            {
+                ValidateKeyType();
+            }
+
+            public ConcurrentIndexedDictionary(bool bReplaceDuplicateKeys)
+            {
+                ValidateKeyType();
+                m_bReplaceDuplicateKeys = bReplaceDuplicateKeys;
+            }
+
+            public ConcurrentIndexedDictionary(bool bReplaceDuplicateKeys, bool bThrowErrorOnInvalidRemove)
+                : this(bReplaceDuplicateKeys)
+            {
+                ValidateKeyType();
+                m_bThrowErrorOnInvalidRemove = bThrowErrorOnInvalidRemove;
+            }
+
+            /// <summary>
+            /// Makes sure int is not used as dictionary key:
+            /// </summary>
+            private static void ValidateKeyType()
+            {
+                if (typeof(TKey) == typeof(int))
+                {
+                    throw new IndexedDictionaryException("Key of type int is not supported.");
+                }
+            }
+
+
+            #endregion
+
+            #region Properties
+
+            public bool ReplaceDuplicateKeys
+            {
+                get { return m_bReplaceDuplicateKeys; }
+            }
+
+            public bool ThrowErrorOnInvalidRemove
+            {
+                get { return m_bThrowErrorOnInvalidRemove; }
+            }
+
+            #endregion
+
+            #region Methods
+
+            /// <summary>
+            /// Override in derived class to manipulate key
+            /// </summary>
+            /// <param name="key"></param>
+            /// <returns></returns>
+            protected virtual TKey TransformKey(TKey key)
+            {
+                return key;
+            }
+
+            public bool Contains(TKey key)
+            {
+                return base.ContainsKey(TransformKey(key));
+            }
+
+            public new virtual void Add(TKey key, TValue item)
+            {
+                AddAt(-1, key, item);
+            }
+
+            public virtual void AddAt(int index, TKey key, TValue item)
+            {
+                DictionaryBeforeEventArgs<TKey, TValue> e = new DictionaryBeforeEventArgs<TKey, TValue>
+                    (key, item);
+
+                // Raise before events:
+                bool bubble = true;
+                if (BeforeAdd != null)
+                {
+                    foreach (DictionaryBeforeDelegate<TKey, TValue> function in BeforeAdd.GetInvocationList())
+                    {
+                        e.Bubble = true;
+                        function.Invoke(this, e);
+                        bubble = bubble && e.Bubble;
+                    }
+                }
+                if (!bubble) return;
+
+                // Add item:
+                // Use value returned by event:
+                if (m_bReplaceDuplicateKeys && ContainsKey(TransformKey(e.Key))) //check if it contains and remove
+                    Remove(TransformKey(e.Key));
+
+                var added = base.TryAdd(TransformKey(e.Key), e.Value);
+
+                if (added)
+                {
+                    if (index != -1)
+                        m_col.Insert(index, e.Key);
+                    else
+                        m_col.Add(e.Key);
+
+                    // Raise after events:
+                    AfterAdd?.Invoke(this, e);
+                }                
+            }
+
+            public virtual void RemoveAt(int index)
+            {
+                if (m_bThrowErrorOnInvalidRemove)
+                    if (index < 0 || index >= m_col.Count)
+                        throw new IndexedDictionaryException("Cannot remove invalid Index");
+                TKey key = m_col[index];
+                Remove(TransformKey(key));
+            }
+
+            public new void Remove(TKey key)
+            {
+                bool bContains = ContainsKey(TransformKey(key));
+                if (m_bThrowErrorOnInvalidRemove && !bContains)
+                    throw new IndexedDictionaryException("Key does not exist within the Dictionary");
+                else if (!bContains)
+                    return;
+
+                // Raise before events:
+                DictionaryBeforeEventArgs<TKey, TValue> e = new DictionaryBeforeEventArgs<TKey, TValue>
+                    (key, base[TransformKey(key)]);
+
+                // Raise before events:
+                bool bubble = true;
+                if (BeforeRemove != null)
+                {
+                    foreach (DictionaryBeforeDelegate<TKey, TValue> function in BeforeRemove.GetInvocationList())
+                    {
+                        e.Bubble = true;
+                        function.Invoke(this, e);
+                        bubble = bubble && e.Bubble;
+                    }
+                }
+                if (!bubble) return;
+
+                // Remove item:
+                // Use value returend by event:                
+                var removed = base.TryRemove(TransformKey(e.Key), out TValue value);
+                if (removed)
+                {
+                    m_col.Remove(e.Key);
+                    // Raise after events:
+                    if (AfterRemove != null)
+                    {
+                        AfterRemove.Invoke(this, e);
+                    }
+                }
+               
             }
 
             public TKey GetKeyByIndex(int index)

--- a/src/LogoFX.Client.Mvvm.ViewModel/WrappingCollection.InternalCollectionManagement.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel/WrappingCollection.InternalCollectionManagement.cs
@@ -92,6 +92,7 @@ namespace LogoFX.Client.Mvvm.ViewModel
 
             public void RemoveRange(IEnumerable<object> items)
             {
+                BeforeClear?.Invoke(this , new BeforeClearEventArgs(items));
                 items.ForEach(r => _items.Remove(r));
             }
 

--- a/src/LogoFX.Client.Mvvm.ViewModel/WrappingCollection.Notifiers.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel/WrappingCollection.Notifiers.cs
@@ -10,7 +10,7 @@ namespace LogoFX.Client.Mvvm.ViewModel
 {
     public partial class WrappingCollection
     {
-        private readonly Dictionary<object, IndexedDictionary<object, object>> _dictionary = new Dictionary<object, IndexedDictionary<object, object>>();
+        private readonly Dictionary<object, IIndexedDictionary<object, object>> _dictionary = new Dictionary<object, IIndexedDictionary<object, object>>();
 
         private NotifyCollectionChangedEventHandler _weakHandler;
 
@@ -23,14 +23,14 @@ namespace LogoFX.Client.Mvvm.ViewModel
         private void PutWrapper(object list, object model, object wrapper)
         {
             if (!_dictionary.ContainsKey(list))
-                _dictionary.Add(list, new IndexedDictionary<object, object>());
+                _dictionary.Add(list, _indexedDictionaryFactory.Create<object, object>());
             _dictionary[list].Add(model,wrapper);
         }
 
         private void PutWrapperAt(object list, object o, object wrapper, int index)
         {
             if (!_dictionary.ContainsKey(list))
-                _dictionary.Add(list, new IndexedDictionary<object, object>());
+                _dictionary.Add(list, _indexedDictionaryFactory.Create<object, object>());
             _dictionary[list].AddAt(index,o,wrapper);            
         }
 
@@ -44,14 +44,14 @@ namespace LogoFX.Client.Mvvm.ViewModel
         private object GetWrapperAt(object list, int index)
         {
             if (!_dictionary.ContainsKey(list))            
-                _dictionary.Add(list, new IndexedDictionary<object, object>());            
+                _dictionary.Add(list, _indexedDictionaryFactory.Create<object, object>());            
             return _dictionary[list].Count>=index+1?_dictionary[list][index]:null;
         }
 
-        private Dictionary<object, object> GetListWrappers(object list)
+        private IIndexedDictionary<object, object> GetListWrappers(object list)
         {
             if (!_dictionary.ContainsKey(list))
-                return new Dictionary<object, object>();
+                return _indexedDictionaryFactory.Create<object, object>();            
             return _dictionary[list];
         }       
 
@@ -266,7 +266,7 @@ namespace LogoFX.Client.Mvvm.ViewModel
                     });
                     break;
                 case NotifyCollectionChangedAction.Reset:
-                    Dictionary<object, object> listWrappers = GetListWrappers(sender);
+                    var listWrappers = GetListWrappers(sender);
 
                     Dispatch.Current.BeginOnUiThread(() =>
                     {

--- a/src/LogoFX.Client.Mvvm.ViewModel/WrappingCollection.Notifiers.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel/WrappingCollection.Notifiers.cs
@@ -10,9 +10,9 @@ namespace LogoFX.Client.Mvvm.ViewModel
 {
     public partial class WrappingCollection
     {
-        readonly Dictionary<object, IndexedDictionary<object, object>> _dictionary = new Dictionary<object, IndexedDictionary<object, object>>();
+        private readonly Dictionary<object, IndexedDictionary<object, object>> _dictionary = new Dictionary<object, IndexedDictionary<object, object>>();
 
-        private NotifyCollectionChangedEventHandler _weakHandler = null;
+        private NotifyCollectionChangedEventHandler _weakHandler;
 
         private object GetWrapper(object list, object model)
         {
@@ -43,7 +43,6 @@ namespace LogoFX.Client.Mvvm.ViewModel
 
         private object GetWrapperAt(object list, int index)
         {
-
             if (!_dictionary.ContainsKey(list))            
                 _dictionary.Add(list, new IndexedDictionary<object, object>());            
             return _dictionary[list].Count>=index+1?_dictionary[list][index]:null;
@@ -54,19 +53,9 @@ namespace LogoFX.Client.Mvvm.ViewModel
             if (!_dictionary.ContainsKey(list))
                 return new Dictionary<object, object>();
             return _dictionary[list];
-        }
+        }       
 
-        private void InvokeOnUiThread(Action a)
-        {
-#if WinRT
-            Dispatch.Current.OnUiThread(
-#else
-            Dispatch.Current.BeginOnUiThread(
-#endif
-a);
-        }
-
-        private void AddList(IEnumerable i)
+        private void AddList(IEnumerable enumerable)
         {
             //make sure we catch collection changes
             IList<object> l;
@@ -74,7 +63,7 @@ a);
             {
                 try
                 {
-                    l = i.Cast<object>().ToList();
+                    l = enumerable.Cast<object>().ToList();
                 }
                 catch
                 {
@@ -83,19 +72,19 @@ a);
                 break;
             } while (true);
 
-            l.ForEach(item => ListCollectionChanged(i, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, -1)));
+            l.ForEach(item => ListCollectionChanged(enumerable, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, -1)));
 
-            if (i is INotifyCollectionChanged)
+            if (enumerable is INotifyCollectionChanged notifyCollectionChanged)
             {
                 if (_weakHandler == null)
                 {
                     _weakHandler = WeakDelegate.From(ListCollectionChanged);
                 }
 
-                ((INotifyCollectionChanged)i).CollectionChanged += _weakHandler;
+                notifyCollectionChanged.CollectionChanged += _weakHandler;
             }
         }
-        private void RemoveList(IEnumerable i)
+        private void RemoveList(IEnumerable enumerable)
         {
             //make sure we catch collection changes
             IList<object> l;
@@ -103,7 +92,7 @@ a);
             {
                 try
                 {
-                    l = i.Cast<object>().ToList();
+                    l = enumerable.Cast<object>().ToList();
                 }
                 catch
                 {
@@ -112,10 +101,10 @@ a);
                 break;
             } while (true);
 
-            if (i is INotifyCollectionChanged && _weakHandler != null)
-                ((INotifyCollectionChanged)i).CollectionChanged -= _weakHandler;
+            if (enumerable is INotifyCollectionChanged notifyCollectionChanged && _weakHandler != null)
+                notifyCollectionChanged.CollectionChanged -= _weakHandler;
 
-            l.ForEach(item => ListCollectionChanged(i, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, -1)));
+            l.ForEach(item => ListCollectionChanged(enumerable, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, -1)));
         }
         private void SourcesCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
@@ -150,26 +139,26 @@ a);
         {
             Action<object> RemoveHandler = (a) =>
             {
-                object o = GetWrapper(sender, a);
+                var wrapper = GetWrapper(sender, a);
                 RemoveWrapper(sender, a);
-                _collectionManager.Remove(o);
-                if (o is IDisposable)
-                    ((IDisposable)o).Dispose();
+                _collectionManager.Remove(wrapper);
+                if (wrapper is IDisposable disposable)
+                    disposable.Dispose();
             };
             Action<IEnumerable<object>> RemoveRangeHandler = collection =>
             {
                 var wrappers = collection.Select(r => new Tuple<object, object>(GetWrapper(sender, r), r)).ToArray();
                 wrappers.ForEach(a => RemoveWrapper(sender, a.Item2));
                 _collectionManager.RemoveRange(wrappers.Select(t => t.Item1));
-                wrappers.ForEach(o =>
+                wrappers.ForEach(wrapper =>
                 {
-                    if (o is IDisposable)
-                        ((IDisposable) o).Dispose();
+                    if (wrapper is IDisposable disposable)
+                        disposable.Dispose();
                 });
             };
             Action<object> AddHandler = (a) =>
             {
-                object wrapper = CreateWrapper(a);
+                var wrapper = CreateWrapper(a);
                 PutWrapper(sender, a, wrapper);
                 _collectionManager.Add(wrapper);
             };
@@ -202,7 +191,7 @@ a);
                 wrappers.ForEach(r =>
                 {
                     var oldWrapper = GetWrapperAt(sender, r.Item3);
-                    int oldIndex = _collectionManager.IndexOf(oldWrapper);
+                    var oldIndex = _collectionManager.IndexOf(oldWrapper);
                     PutWrapperAt(sender, r.Item1, r.Item2, r.Item3);
                     if (oldWrapper != null && oldIndex >= 0)
                     {
@@ -224,51 +213,51 @@ a);
                 case NotifyCollectionChangedAction.Add:                    
                     if (e.NewStartingIndex == -1)
                     {
-                        InvokeOnUiThread(() => AddRangeHandler(e.NewItems.Cast<object>()));                        
+                        Dispatch.Current.BeginOnUiThread(() => AddRangeHandler(e.NewItems.Cast<object>()));                        
                     }
                     else
                     {
-                        InvokeOnUiThread(() =>
+                        Dispatch.Current.BeginOnUiThread(() =>
                         {
-                            int newindex = e.NewStartingIndex;
-                            InsertRangeHandler(e.NewItems.Cast<object>(), newindex);
+                            var newStartingIndex = e.NewStartingIndex;
+                            InsertRangeHandler(e.NewItems.Cast<object>(), newStartingIndex);
                         });
                     }
                     break;
                 case NotifyCollectionChangedAction.Remove:
-                    InvokeOnUiThread(() => RemoveRangeHandler(e.OldItems.Cast<object>()));
+                    Dispatch.Current.BeginOnUiThread(() => RemoveRangeHandler(e.OldItems.Cast<object>()));
                     break;
                 case NotifyCollectionChangedAction.Move:
-                    InvokeOnUiThread(() =>
+                    Dispatch.Current.BeginOnUiThread(() =>
                     {
                         RemoveRangeHandler(e.OldItems.Cast<object>());
 
                         if (e.NewStartingIndex == -1)
                         {
-                            InvokeOnUiThread(() => AddRangeHandler(e.NewItems.Cast<object>()));
+                            Dispatch.Current.BeginOnUiThread(() => AddRangeHandler(e.NewItems.Cast<object>()));                            
                         }
                         else
                         {
-                            InvokeOnUiThread(() =>
+                            Dispatch.Current.BeginOnUiThread(() =>
                             {
-                                int newindex = e.NewStartingIndex;
-                                InsertRangeHandler(e.NewItems.Cast<object>(), newindex);
+                                var newStartingIndex = e.NewStartingIndex;
+                                InsertRangeHandler(e.NewItems.Cast<object>(), newStartingIndex);
                             });
                         }
                     });
                     break;
                 case NotifyCollectionChangedAction.Replace:
-                    InvokeOnUiThread(() =>
+                    Dispatch.Current.BeginOnUiThread(() =>
                     {
                         RemoveRangeHandler(e.OldItems.Cast<object>());
 
                         if (e.NewStartingIndex == -1)
                         {
-                            InvokeOnUiThread(() => AddRangeHandler(e.NewItems.Cast<object>()));
+                            Dispatch.Current.BeginOnUiThread(() => AddRangeHandler(e.NewItems.Cast<object>()));
                         }
                         else
                         {
-                            InvokeOnUiThread(() =>
+                            Dispatch.Current.BeginOnUiThread(() =>
                             {
                                 int newindex = e.NewStartingIndex;
                                 InsertRangeHandler(e.NewItems.Cast<object>(), newindex);
@@ -277,14 +266,14 @@ a);
                     });
                     break;
                 case NotifyCollectionChangedAction.Reset:
-                    Dictionary<object, object> listwrappers = GetListWrappers(sender);
+                    Dictionary<object, object> listWrappers = GetListWrappers(sender);
 
-                    InvokeOnUiThread(() =>
+                    Dispatch.Current.BeginOnUiThread(() =>
                     {
-                        if (listwrappers.Count > 0)
+                        if (listWrappers.Count > 0)
                         {
-                            RemoveRangeHandler(listwrappers.Select(a => a.Key).ToList());
-                            listwrappers.Clear();                                                    
+                            RemoveRangeHandler(listWrappers.Select(a => a.Key).ToList());
+                            listWrappers.Clear();                                                    
                         }                        
                     });
                     break;

--- a/src/LogoFX.Client.Mvvm.ViewModel/WrappingCollection.WithSelection.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel/WrappingCollection.WithSelection.cs
@@ -44,8 +44,9 @@ namespace LogoFX.Client.Mvvm.ViewModel
             /// Initializes a new instance of the <see cref="WrappingCollection.WithSelection"/> class.
             /// </summary>
             /// <param name="selectionMode">The selection mode. Cannot be used together with selection predicate.</param>
-            /// <param name="isBulk">if set to <c>true</c> uses bulk operations mode.</param>
-            public WithSelection(SelectionMode selectionMode = DefaultSelectionMode, bool isBulk = false)
+            /// <param name="isBulk">Set to <c>true</c> to enable bulk operations mode.</param>
+            /// <param name="isConcurrent">Set to <c>true</c>for concurrent support.</param>
+            public WithSelection(SelectionMode selectionMode = DefaultSelectionMode, bool isBulk = false, bool isConcurrent = false)
                 : base(isBulk)
             {
                 _selectionMode = selectionMode;
@@ -56,13 +57,41 @@ namespace LogoFX.Client.Mvvm.ViewModel
             /// Initializes a new instance of the <see cref="WrappingCollection.WithSelection"/> class.
             /// </summary>
             /// <param name="selectionPredicate">The selection predicate. Cannot be used together with selection mode.</param>
-            /// <param name="isBulk">if set to <c>true</c> uses bulk operations mode.</param>
-            public WithSelection(Predicate<object> selectionPredicate = null, bool isBulk = false)
+            /// <param name="isBulk">Set to <c>true</c> to enable bulk operations mode.</param>
+            /// <param name="isConcurrent">Set to <c>true</c>for concurrent support.</param>
+            public WithSelection(Predicate<object> selectionPredicate = null, bool isBulk = false, bool isConcurrent = false)
                 : base(isBulk)
             {
                 _selectionPredicate = selectionPredicate;
                 _selectedItems.CollectionChanged += (a, b) => OnSelectionChanged();
             }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="WrappingCollection.WithSelection"/> class.
+            /// </summary>
+            /// <param name="configSelectionSetupOptions">The selection setup options configuration.</param>
+            public WithSelection(Func<SelectionSetupOptions, SelectionSetupOptions> configSelectionSetupOptions)
+                : this(configSelectionSetupOptions(new SelectionSetupOptions()))
+            {
+            }
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="WrappingCollection.WithSelection"/> class.
+            /// </summary>
+            /// <param name="selectionSetupOptions">The selection setup options.</param>
+            public WithSelection(SelectionSetupOptions selectionSetupOptions)
+                :base(selectionSetupOptions)
+            {
+                if (_selectionPredicate != null)
+                {
+                    _selectionPredicate = selectionSetupOptions.SelectionPredicate;
+                }
+                else
+                {
+                    _selectionMode = selectionSetupOptions.SelectionMode;
+                }
+                _selectedItems.CollectionChanged += (a, b) => OnSelectionChanged();
+            }            
 
             #region Private implementation
             private bool HandleItemSelectionChanged(object obj, bool isSelecting)

--- a/src/LogoFX.Client.Mvvm.ViewModel/WrappingCollectionExtensions.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel/WrappingCollectionExtensions.cs
@@ -23,10 +23,10 @@ namespace LogoFX.Client.Mvvm.ViewModel
         public static T WithSource<T>(this T collection, IEnumerable source) where T : WrappingCollection
         {
             if (collection == null)
-                throw new ArgumentNullException("collection");
+                throw new ArgumentNullException(nameof(collection));
 
             if (source == null)
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
 
             collection.AddSource(source);
 

--- a/src/LogoFX.Client.Mvvm.ViewModel/WrappingCollectionExtensions.cs
+++ b/src/LogoFX.Client.Mvvm.ViewModel/WrappingCollectionExtensions.cs
@@ -15,7 +15,7 @@ namespace LogoFX.Client.Mvvm.ViewModel
         /// <param name="collection">The specified collection.</param>
         /// <param name="source">The source.</param>
         /// <returns></returns>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         /// collection
         /// or
         /// source


### PR DESCRIPTION
This set of changes introduces support for concurrent dictionary inside the `WrappingCollection` to cope with concurrency issues. See #6 for instance